### PR TITLE
Fix post retrieval getting everything

### DIFF
--- a/src/main/java/ch/nexusnet/postmanager/aws/dynamodb/repositories/DynamoDBPostRepository.java
+++ b/src/main/java/ch/nexusnet/postmanager/aws/dynamodb/repositories/DynamoDBPostRepository.java
@@ -9,5 +9,7 @@ import java.util.List;
 @EnableScan
 public interface DynamoDBPostRepository extends CrudRepository<DynamoDBPost, String> {
     List<DynamoDBPost> findByAuthorId(String authorId);
+
+    List<DynamoDBPost> findDynamoDBPostsByIdStartingWith(String id);
 }
 

--- a/src/main/java/ch/nexusnet/postmanager/service/PostServiceImpl.java
+++ b/src/main/java/ch/nexusnet/postmanager/service/PostServiceImpl.java
@@ -50,7 +50,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<Post> findAllPosts() {
-        return StreamSupport.stream(dynamoDBPostRepository.findAll().spliterator(), false)
+        return StreamSupport.stream(dynamoDBPostRepository.findDynamoDBPostsByIdStartingWith("POST").spliterator(), false)
                 .map(DynamoPostToPostMapper::map)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/ch/nexusnet/postmanager/controller/PostControllerIntegrationTests.java
+++ b/src/test/java/ch/nexusnet/postmanager/controller/PostControllerIntegrationTests.java
@@ -135,7 +135,8 @@ public class PostControllerIntegrationTests {
     public void testGetAllPosts() throws Exception {
         mockMvc.perform(get("/posts"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray());
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(1));
     }
 
     @Test


### PR DESCRIPTION
Modified the retrieve all posts functionality to now filter results based on ID starting with "POST" so comments and likes do not get retrieved also. Updated the associated test to count the array length to ensure the response is as expected.